### PR TITLE
Todo検索機能の実装

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,25 +6,97 @@ import { TodoArea } from "./components/TodoArea";
 import "./CSS/style.scss";
 
 export const App = () => {
-  const [inputTodo, setInputTodo] = useState("");
-  const [todos, setTodos] = useState(["Todo1", "Todo2"]);
+  // Todo検索時に各Todoに表示非表示の判定をするフラグが必要となったため、Todoのデータ型を連想配列にした
+  const initialTasks = [
+    {
+      id: 1,
+      title: "Todo1",
+      todoShowFlag: true,
+    },
+    {
+      id: 2,
+      title: "Todo2",
+      todoShowFlag: true,
+    },
+  ];
 
+  // task追加時にIdを連番にするために定義
+  // 初期のtaskが2つあるため2から始める
+  // CATION   !!!!：テストのためのデータを消す場合は初期値を0にする!!!!!!!
+  const [currentId, setCurrentId] = useState(2);
+  // 新しいtodoの入力値を保持するstate
+  const [inputTodo, setInputTodo] = useState("");
+
+  // 表示するtodoListを保持するstate
+  // 検索機能を実装する前の名残
+  // const [todos, setTodos] = useState(["Todo1", "Todo2"]);
+  // TodoListの初期値を読み込み
+  let [todos, setTodos] = useState(initialTasks);
+
+  // 検索キーワードを保持するstate
+  const [searchKeyword, setSearchKeyword] = useState("");
+
+  // todo追加機能
   const onChangeInputTodo = (event) => setInputTodo(event.target.value);
 
   const pressEnter = (event) => {
     if (event.key === "Enter") {
       // 空文字もしくはスペースのみのときは処理を抜ける
       if (inputTodo === "" || !inputTodo.match(/\S/g)) return;
+      // 新しく追加するためのtaskを定義する
+      const newTask = {
+        id: currentId + 1,
+        title: inputTodo,
+        todoShowFlag: true,
+      };
 
-      const newTodos = [...todos, inputTodo];
+
+      const newTodos = [...todos, newTask];
       setTodos(newTodos);
+
+      // inputFormを空にする
       setInputTodo("");
+      // 次のtaskのidが重複しないように +1しておく
+      setCurrentId(currentId + 1);
     }
   };
 
-  const onClickDelete = (index) => {
-    const deletedTodos = [...todos];
-    deletedTodos.splice(index, 1);
+  // 検索機能(仮) => 検索ワードから外れたTodoは削除されてしまう
+  // filterを使用してtodoの配列から外れた要素を削除しているのが問題。
+  // const onChangeSearchTodo = (event) => {
+  //   const searchKeyword = event.target.value;
+  //   const regexp = new RegExp("^" + searchKeyword, "i");
+  //   const searchedTodos = todos.filter((event) => event.match(regexp));
+  //   setTodos(searchedTodos);
+  // };
+
+  // todoの検索ワードを受け取る関数
+  const onChangeSearchTodo = (event) => {
+    setSearchKeyword(event.target.value);
+  };
+
+  // 検索ワードに一致したTodoのshowFlagを変更する関数
+  const changeShowFlag = () => {
+    //　先頭一致の正規表現を作成
+    const regexp = new RegExp("^" + searchKeyword, "i");
+
+    // Todoと検索ワードが先頭から部分一しない場合はshowFlagをfalseにする
+    for (const todo of todos) {
+      if (!todo.title.match(regexp)) {
+        todo.todoShowFlag = false;
+      } else {
+        todo.todoShowFlag = true;
+      }
+    }
+  };
+
+  // showFlagを変更する関数を実行
+  changeShowFlag();
+
+  // 削除機能
+  const onClickDelete = (taskId) => {
+    // 削除ボタンが押されたtaskのIdに一致しないtaskで新たにtodoListを作成する
+    const deletedTodos = todos.filter((todos) => todos.id !== taskId);
     setTodos(deletedTodos);
   };
 
@@ -33,12 +105,14 @@ export const App = () => {
       <h1 className="title">Todo List</h1>
       <h2 className="sub-title">ADD TODO</h2>
       <div className="wrapper">
-      <InputArea
-        inputTodo={inputTodo}
-        onChange={onChangeInputTodo}
-        onKeyPress={pressEnter}
-      />
-      <TodoArea todos={todos} onClickDelete={onClickDelete} />
+        <InputArea
+          inputTodo={inputTodo}
+          onChange={onChangeInputTodo}
+          onKeyPress={pressEnter}
+          placeholder={"New Todo"}
+        />
+        <InputArea onChange={onChangeSearchTodo} placeholder={"Search Todo"} />
+        <TodoArea todos={todos} onClickDelete={onClickDelete} />
       </div>
     </>
   );

--- a/src/components/InputArea.jsx
+++ b/src/components/InputArea.jsx
@@ -1,12 +1,12 @@
 import React from "react";
 
 export const InputArea = (props) => {
-  const { inputTodo, onChange, onKeyPress } = props;
+  const { inputTodo, onChange, onKeyPress, placeholder } = props;
 
   return (
       <input
         type="text"
-        placeholder="New Todo"
+        placeholder={placeholder}
         value={inputTodo}
         onChange={onChange}
         onKeyPress={onKeyPress}

--- a/src/components/TodoArea.jsx
+++ b/src/components/TodoArea.jsx
@@ -3,24 +3,24 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faTrashAlt } from "@fortawesome/free-regular-svg-icons";
 
 export const TodoArea = (props) => {
-  const { todos, onClickDelete } = props;
+  const { todos, onClickDelete} = props;
 
   return (
     <>
       <ul>
-        {todos.map((todo, index) => {
+        {todos.map((todo) => {
           return (
-            <div key={todo} className="todo-list">
-              <li className="list-low">
-                {todo}
+            <div key={todo.id} className="todo-list">
+              {todo.todoShowFlag && <li className="list-low">
+                {todo.title}
                 {/* 引数を渡した関数をonClickに指定すると画面がレンダリングされた際にonClickイベントが発火してしまうためアロー関数にして指定する */}
                 <FontAwesomeIcon
-                  onClick={() => onClickDelete(index)}
+                  onClick={() => onClickDelete(todo.id)}
                   icon={faTrashAlt}
                   alt="削除"
                   className="icon"
                 />
-              </li>
+              </li> }
             </div>
           );
         })}


### PR DESCRIPTION
Closes #13 

## 変更の概要

- #13 
- 全体の実装の見直し


## やったこと

- [x]  todoのデータ型を連想配列に変更した(keyはid, title, todoShowFlag)
- [x]  todo追加機能を上記のデータ型に合わせて実装を変更した
- [x]  todo削除機能も配列のindexで指定するのではなく各todoが持つidを指定して削除するように変更した
- [x]  todoをレンダリングする部分でkeyをtodo.idに変更
- [x]  検索機能の実装
- [x]  各todoをtodoShowFlagによってレンダリングするか否か指定するようにした